### PR TITLE
Fix triggerReturn for backToReferer events

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -159,13 +159,17 @@
     });
   }
 
+  var waitingForReturn = false;
   // returns nothing
   function triggerEvent(evt) {
+    waitingForReturn = true;
     getPageWorkerAnd(function(pageWorker) {
       nbEventsTriggeredOnPage++;
       nbEventsTriggeredTotal++;
-      pageWorker.port.once("triggerReturn", triggerReturn);
+      pageWorker.port.once("triggerReturn", triggerByPort);
       pageWorker.port.emit("trigger", evt);
+      pageWorker.removeListener("detach", triggerByDetach);
+      pageWorker.on("detach", triggerByDetach);
 
       if (nbEventsTriggeredOnPage % 100 === 0) {
         console.log("Nb of triggered events: " + nbEventsTriggeredOnPage);
@@ -179,6 +183,19 @@
   }
 
   var triggerReturn;
+
+  var triggerByPort = () => triggerTriggerReturn("port");
+  var triggerByDetach = () => triggerTriggerReturn("detach");
+
+  function triggerTriggerReturn(origin) {
+    if (waitingForReturn === true) {
+      console.log("Received trigger return from " + origin);
+      waitingForReturn = false;
+      triggerReturn();
+    } else {
+      console.log("Received trigger return from " + origin + ", but not waiting for it.");
+    }
+  }
 
   function registerTriggerReturn(callback) {
     triggerReturn = callback;


### PR DESCRIPTION
Some `backToReferer` events would leave the page before the handler for the `triggerReturn` event was fired, leading to a missing `triggerReturn` event. If `triggerIfHanging` is disabled, this leads for the event triggering to stop.

The fix introduces a new onDetach handler for `page-mod` to make sure `triggerReturn` executes. A guard boolean prevents `triggerReturn` from happening twice for the same event.
