### PR TITLE
Trigger next event immediately after hang

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 (function() {
   
-  var minDelayBetweenEvents = 2000; // ms
-  var maxDelayBetweenEvents = 2000; // ms
+  var minDelayBetweenEvents = 1000; // ms
+  var maxDelayBetweenEvents = 1000; // ms
 
   function getMinDelayBetweenEvents() {
     return minDelayBetweenEvents;

--- a/lib/main.js
+++ b/lib/main.js
@@ -92,15 +92,19 @@
     };
 
     var lastTriggerReturn;
-    function triggerReturn() {
+    function triggerReturn(immediate) {
         lastTriggerReturn = new Date().getTime();
         console.log("Receiving triggerReturn in main.js");
         if (eventTriggeringEnabled) {
-            var interval = config.getMaxDelayBetweenEvents() - config.getMinDelayBetweenEvents();
-            var randFromInterval = commonUtil.randInt(interval + 1);
-            var delay = config.getMinDelayBetweenEvents() + randFromInterval;
-            console.log("Will trigger next event after " + delay + " ms");
-            timers.setTimeout(tryToTrigger, delay);
+            if (immediate) {
+                timers.setTimeout(tryToTrigger, 0);
+            } else {
+                var interval = config.getMaxDelayBetweenEvents() - config.getMinDelayBetweenEvents();
+                var randFromInterval = commonUtil.randInt(interval + 1);
+                var delay = config.getMinDelayBetweenEvents() + randFromInterval;
+                console.log("Will trigger next event after " + delay + " ms");
+                timers.setTimeout(tryToTrigger, delay);
+            }
         }
     }
 
@@ -109,9 +113,11 @@
             if (eventTriggeringEnabled) {
                 var now = new Date().getTime();
                 console.log("Checking if triggerReturn is hanging: now=" + now + ", lastTriggerReturn=" + lastTriggerReturn);
-                if (!lastTriggerReturn || (lastTriggerReturn + (1000 * 2)) < now) {
+                if (!lastTriggerReturn || (lastTriggerReturn + (3000 * 2)) < now) {
                     console.log("Seems to hang -- calling triggerReturn()");
-                    timers.setTimeout(triggerReturn, 0);
+                    timers.setTimeout(function() {
+                        triggerReturn(true)
+                    }, 0);
                 }
             }
         }, 1000 * 1);


### PR DESCRIPTION
Don't wait with triggering a next event after a hang, so that we don't detect another hang due to the waiting period of triggering a new event.

I adjusted the delay between events (from 2s to 1s) and the hang timeout (from 2s to 3s), which creates significantly less hangs.
