### PR TITLE
Updated array shuffling to use an unbiased algorithm

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,17 +1,18 @@
 (function() {
-  
+
   var chrome = require("chrome");
   var currentDir = chrome.Cc["@mozilla.org/file/directory_service;1"]
       .getService(chrome.Ci.nsIDirectoryServiceProvider)
       .getFile("CurWorkD", {}).path;
-  
+
   function shuffle(array) {
-    return array.sort(function(x, y) {
-      if (Math.random() > 0.5)
-        return -1;
-      else
-        return 1;
-    });
+    for (var i = array.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var temp = array[i];
+      array[i] = array[j];
+      array[j] = temp;
+    }
+    return array;
   }
 
   function unwrapObject(object) {
@@ -28,7 +29,7 @@
 
     return object;
   }
-  
+
   function getCurrentDir() {
     return currentDir;
   }


### PR DESCRIPTION
This updates the array shuffling to use an [unbiased shuffling algorithm](https://en.wikipedia.org/wiki/Fisher–Yates_shuffle).

The previous version was biased towards keeping elements close to their previous position, depending on the implementation of JavaScript's sorting algorithm.
